### PR TITLE
Added support for specifying Zookeeper root

### DIFF
--- a/stormkafkamon/monitor.py
+++ b/stormkafkamon/monitor.py
@@ -75,6 +75,8 @@ def read_args():
                         help='Zookeeper host (default: localhost)')
     parser.add_argument('--zport', type=int, default=2181,
                         help='Zookeeper port (default: 2181)')
+    parser.add_argument('--zroot', type=str, default='/',
+                        help='Zookeeper root directory (default: /)')
     parser.add_argument('--topology', type=str, required=True,
                         help='Storm Topology')
     parser.add_argument('--spoutroot', type=str, required=True,
@@ -89,7 +91,7 @@ def read_args():
 def main():
     options = read_args()
 
-    zc = ZkClient(options.zserver, options.zport)
+    zc = ZkClient(options.zserver, options.zport, options.zroot)
 
     try:
         zk_data = process(zc.spouts(options.spoutroot, options.topology))

--- a/stormkafkamon/processor.py
+++ b/stormkafkamon/processor.py
@@ -14,9 +14,8 @@ logger = logging.getLogger('kafka.codec').addHandler(NullHandler())
 import struct
 import socket
 from collections import namedtuple
-from kafka.client import KafkaClient
+from kafka import SimpleClient
 from kafka.common import OffsetRequestPayload
-
 
 class ProcessorError(Exception):
 
@@ -62,15 +61,15 @@ def process(spouts):
     for s in spouts:
         for p in s.partitions:
             try:
-                k = KafkaClient(p['broker']['host'], p['broker']['port'])
+                k = SimpleClient(p['broker']['host'] + ':' + str(p['broker']['port']))
             except socket.gaierror as e:
                 raise ProcessorError('Failed to contact Kafka broker %s (%s)' %
                                      (p['broker']['host'], str(e)))
-            earliest_off = OffsetRequest(p['topic'], p['partition'], -2, 1)
-            latest_off = OffsetRequest(p['topic'], p['partition'], -1, 1)
+            earliest_off = [OffsetRequestPayload(p['topic'], p['partition'], -2, 1)]
+            latest_off = [OffsetRequestPayload(p['topic'], p['partition'], -1, 1)]
 
-            earliest = k.get_offsets(earliest_off)[0]
-            latest = k.get_offsets(latest_off)[0]
+            earliest = k.send_offset_request(earliest_off)[0].offsets[0]
+            latest = k.send_offset_request(latest_off)[0].offsets[0]
             current = p['offset']
 
             brokers.append(p['broker']['host'])


### PR DESCRIPTION
The `--zroot` option can be used to specify the Zookeeper root directory.